### PR TITLE
mount projects/icmib-acme/db to acme/db

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,7 @@ services:
     volumes:
       - ~/projects/icmib:/icmib
       - /icmib/node_modules
-      - ~/projects/icmib/db:/db
+      - ~/projects/icmib-acme/db:/acme/db
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
this lets the rake task in icmib copy the schema file to acme.