### PR TITLE
Adding an elixir extension, removing solargraph

### DIFF
--- a/.devcontainer/acme-container/devcontainer.json
+++ b/.devcontainer/acme-container/devcontainer.json
@@ -7,8 +7,6 @@
   "customizations": {
 		"vscode": {
 			"extensions": [
-        "castwide.solargraph",
-        "rebornix.Ruby",
         "rubocop.vscode-rubocop",
         "Shopify.ruby-lsp"
       ]

--- a/.devcontainer/acme-container/devcontainer.json
+++ b/.devcontainer/acme-container/devcontainer.json
@@ -8,7 +8,9 @@
 		"vscode": {
 			"extensions": [
         "rubocop.vscode-rubocop",
-        "Shopify.ruby-lsp"
+        "Shopify.ruby-lsp",
+        "Shopify.ruby-extensions-pack",
+        "eamodio.gitlens"
       ]
 		}
 	}

--- a/.devcontainer/feedback-container/devcontainer.json
+++ b/.devcontainer/feedback-container/devcontainer.json
@@ -7,7 +7,8 @@
   "customizations": {
 		"vscode": {
 			"extensions": [
-        "JakeBecker.elixir-ls"
+        "JakeBecker.elixir-ls",
+        "eamodio.gitlens"
       ]
 		}
 	}

--- a/.devcontainer/feedback-container/devcontainer.json
+++ b/.devcontainer/feedback-container/devcontainer.json
@@ -7,6 +7,7 @@
   "customizations": {
 		"vscode": {
 			"extensions": [
+        "JakeBecker.elixir-ls"
       ]
 		}
 	}

--- a/.devcontainer/icmib-container/devcontainer.json
+++ b/.devcontainer/icmib-container/devcontainer.json
@@ -7,8 +7,6 @@
   "customizations": {
 		"vscode": {
 			"extensions": [
-        "castwide.solargraph",
-        "rebornix.Ruby",
         "rubocop.vscode-rubocop",
         "Shopify.ruby-lsp"
       ]

--- a/.devcontainer/icmib-container/devcontainer.json
+++ b/.devcontainer/icmib-container/devcontainer.json
@@ -8,7 +8,9 @@
 		"vscode": {
 			"extensions": [
         "rubocop.vscode-rubocop",
-        "Shopify.ruby-lsp"
+        "Shopify.ruby-lsp",
+        "Shopify.ruby-extensions-pack",
+        "eamodio.gitlens"
       ]
 		}
 	}

--- a/.devcontainer/icmu-container/devcontainer.json
+++ b/.devcontainer/icmu-container/devcontainer.json
@@ -7,7 +7,8 @@
   "customizations": {
 		"vscode": {
 			"extensions": [
-        "JakeBecker.elixir-ls"
+        "JakeBecker.elixir-ls",
+        "eamodio.gitlens"
       ]
 		}
 	}

--- a/.devcontainer/icmu-container/devcontainer.json
+++ b/.devcontainer/icmu-container/devcontainer.json
@@ -7,6 +7,7 @@
   "customizations": {
 		"vscode": {
 			"extensions": [
+        "JakeBecker.elixir-ls"
       ]
 		}
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   mongo:
     init: true


### PR DESCRIPTION
- Adding a basic elixir support extension for vscode
- Removing both the rebornix.ruby extension (deprecated) and the solargraph extension, because they both overlap ruby-lsp. Ruby-LSP simplifies things a little bit by not needing a gem in our app. That means we should be able to remove the solargaph gem. 

[ruby-lsp](https://github.com/Shopify/ruby-lsp#overview)