### PR TITLE
add the stubbed livestorm service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -268,3 +268,8 @@ services:
       - ~/projects/icmib-acme:/acme
     tty: true
     stdin_open: true
+
+  stubbed-livestorm-api:
+    image: materialplus/stubbed-livestorm-api:latest
+    ports:
+      - "1975:1975"


### PR DESCRIPTION
this service will listen on port 1975 and serve requests that would normally go to livestorm.

this is useful for local development so we dont have to manage multiple livestorm accounts