### PR TITLE
add todo-tree to out container plugins

### DIFF
--- a/.devcontainer/acme-container/devcontainer.json
+++ b/.devcontainer/acme-container/devcontainer.json
@@ -17,7 +17,8 @@
         "Shopify.ruby-extensions-pack",
         "eamodio.gitlens",
         "ms-azuretools.vscode-docker",
-        "bradlc.vscode-tailwindcss"
+        "bradlc.vscode-tailwindcss",
+        "Gruntfuggly.todo-tree"
       ]
     }
   }

--- a/.devcontainer/icmib-container/devcontainer.json
+++ b/.devcontainer/icmib-container/devcontainer.json
@@ -16,7 +16,8 @@
         "Shopify.ruby-lsp",
         "Shopify.ruby-extensions-pack",
         "eamodio.gitlens",
-        "ms-azuretools.vscode-docker"
+        "ms-azuretools.vscode-docker",
+        "Gruntfuggly.todo-tree"
       ]
 		}
 	}

--- a/.devcontainer/icmu-container/devcontainer.json
+++ b/.devcontainer/icmu-container/devcontainer.json
@@ -14,7 +14,8 @@
 			"extensions": [
         "eamodio.gitlens",
         "ms-azuretools.vscode-docker",
-        "JakeBecker.elixir-ls"
+        "JakeBecker.elixir-ls",
+        "Gruntfuggly.todo-tree"
       ]
 		}
 	}


### PR DESCRIPTION
this is a nice little plugin that puts all the TODO comments into a nice easy format
<img width="350" alt="image" src="https://github.com/user-attachments/assets/2b7cbd74-a2a1-4998-bb66-b8c3cf0eefa5">
